### PR TITLE
Feature/api profesores

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -32,3 +32,8 @@
 - Importación de `patch` y `Mock` en las pruebas unitarias.
 - Importación de la clase `Curso` en las pruebas unitarias.
 - Resolución de problemas con `Base.metadata.create_all` en las pruebas.W
+
+## [1.0.4] - 2025-07-21
+
+### Corregido
+- Se ajusta API Profesor = AUTENTICACION.

--- a/app/services/cursos.py
+++ b/app/services/cursos.py
@@ -1,6 +1,7 @@
 import requests
 from sqlalchemy.orm import Session
 from app.models.cursos import Curso
+from app.schemas.cursos import CursoCreate
 from app.services.profesor import obtener_profesor
 
 API_SEDES_URL = "http://127.0.0.1:8000/sedes"

--- a/app/services/cursos.py
+++ b/app/services/cursos.py
@@ -1,7 +1,7 @@
 import requests
 from sqlalchemy.orm import Session
 from app.models.cursos import Curso
-from app.schemas.cursos import CursoCreate
+from app.services.profesor import obtener_profesor
 
 API_SEDES_URL = "http://127.0.0.1:8000/sedes"
 API_PROFESORES_URL = "http://127.0.0.1:8009/profesor"

--- a/app/services/cursos.py
+++ b/app/services/cursos.py
@@ -4,8 +4,7 @@ from app.models.cursos import Curso
 from app.schemas.cursos import CursoCreate
 
 API_SEDES_URL = "http://127.0.0.1:8000/sedes"
-# REVISAR
-# API_PROFESORES_URL = "http://127.0.0.1:8000/profesor"
+API_PROFESORES_URL = "http://127.0.0.1:8009/profesor"
 
 def sede_existe(id_sede: int) -> bool:
     resp = requests.get(f"{API_SEDES_URL}/{id_sede}")


### PR DESCRIPTION
This pull request includes updates to the changelog and improvements to the `cursos` service to enhance functionality and documentation. The most important changes are grouped below:

### Documentation Updates:
* [`Changelog.md`](diffhunk://#diff-c275fec9c453c2a42515bc5ab47e30fa4130ff1426aef2f6e000a9a34e122cb8R35-R39): Added a new entry for version 1.0.4, documenting a fix related to the "API Profesor = AUTENTICACION" adjustment.

### Code Improvements:
* [`app/services/cursos.py`](diffhunk://#diff-f8df43fe3bba504cf928f6a9b19c1f8e06520722d55f653ed499172f3020bf10R5-R8): Updated the `API_PROFESORES_URL` to point to the correct endpoint (`http://127.0.0.1:8009/profesor`) and removed outdated comments. Additionally, imported the `obtener_profesor` function from `app.services.profesor` for potential future use.